### PR TITLE
Make Postgres port configurable

### DIFF
--- a/config.py
+++ b/config.py
@@ -3,6 +3,7 @@ sql_user = 'lopez'
 sql_pass = 'johny johny telling lies'
 sql_db = 'lopez'
 sql_host = 'localhost'
+sql_port = 5432
 # changing the below line will void the non-existent warranty Lopez came with
 # so please don't
-postgresql = 'postgresql://{0}:{1}@{2}/{3}'.format(sql_user, sql_pass, sql_host, sql_db)
+postgresql = 'postgresql://{0}:{1}@{2}:{3}/{4}'.format(sql_user, sql_pass, sql_host, sql_port, sql_db)


### PR DESCRIPTION
Postgres defaults to port 5432 for connections, but that can be changed. asyncpg supports connecting to non-standard ports by appending a colon and the port number to the hostname.